### PR TITLE
Fix `Blas operations` heading/link

### DIFF
--- a/docs/quick_reference.md
+++ b/docs/quick_reference.md
@@ -271,7 +271,7 @@ output[(i, j)]`. Additional rows and columns are filled with `val`.
 
 -----
 
-#### Blas andoperations
+#### Blas operations
 **nalgebra** implements some Blas operations in pure Rust. In the following,
 the variables $\mathbf{v}$ and $\mathbf{V}$ designs the `self` argument.
 


### PR DESCRIPTION
The navigation at the top of the Quick Reference page was broken because of a typo in the `Blas operations` section of that page.

I wasn't able to run `mkdocs build` successfully, but fixing the typo should fix the navigation.